### PR TITLE
Removed clutter and shrunk some empty space

### DIFF
--- a/templates/form.html
+++ b/templates/form.html
@@ -50,6 +50,7 @@
         select {
             background-color: var(--opossum);
             color: var(--cuttlefish);
+            font-size: 18px;
         }
     
         textarea {
@@ -93,7 +94,7 @@
         }
 
         .audio-list {
-            width: 50%;
+            width: 70%; 
             max-height: 70vh;
             height: 70vh;
             overflow-y: auto;
@@ -101,6 +102,7 @@
             display: flex;
             flex-direction: column;
             align-items: center;
+            margin-left: -300px;
         }
 
         @keyframes fadeIn {
@@ -323,18 +325,7 @@
             </div>
         </form>
 
-        <div class="audio-list">
-            <div class="audio-padding"></div>  <!-- padding div -->
-            {% for text, audio_file, _ in audio_files %}
-                <div class="audio-item">
-                    <div class="audio-item-text">
-                        {{ text }}
-                    </div>                    
-                    <source src="{{ url_for('static', filename='audio/' + audio_file) }}" type="audio/wav">
-                </div>
-            {% endfor %}
-            <div class="audio-padding"></div>  <!-- padding div test-->
-        </div>        
+        <div class="audio-list"/>        
 
     </div>
 </body>


### PR DESCRIPTION
Removed the template's initial HTML for loop to create the initial audio file list because on start up it gets wiped out anyways by `loadInitialAudioList()` .
Also increased the width of the containers to remove some of the empty space in the middle.
Preview:
![image](https://github.com/CoffeeVampir3/audiocraft-webui/assets/9211657/2385c2ea-b57c-402f-b7be-0810b771ec47)
